### PR TITLE
Ensure LastError exception only passes integers

### DIFF
--- a/lib/Horde/Exception/LastError.php
+++ b/lib/Horde/Exception/LastError.php
@@ -48,7 +48,7 @@ class Horde_Exception_LastError extends Horde_Exception
             $this->file = $code_or_lasterror['file'];
             $this->line = $code_or_lasterror['line'];
         } else {
-            parent::__construct($message, $code_or_lasterror);
+            parent::__construct($message, $code_or_lasterror ?? 0);
         }
     }
 

--- a/lib/Horde/Exception/PermissionDenied.php
+++ b/lib/Horde/Exception/PermissionDenied.php
@@ -27,7 +27,7 @@ class Horde_Exception_PermissionDenied extends Horde_Exception
      *
      * @see Horde_Exception::__construct()
      *
-     * @param mixed $message           The exception message, a PEAR_Error
+     * @param string|Exception $message           The exception message, a PEAR_Error
      *                                 object, or an Exception object.
      * @param integer $code            A numeric error code.
      */


### PR DESCRIPTION
As of PHP 8.1, null can no longer be passed to the second constructor
argument of builtin exceptions. It will raise an error, resulting in log spam.

Found executing the test suite of horde/yaml in php 8.1