### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/Exception/LastError.php
+++ b/lib/Horde/Exception/LastError.php
@@ -44,11 +44,11 @@ class Horde_Exception_LastError extends Horde_Exception
             } else {
                 $message = $code_or_lasterror['message'];
             }
-            parent::__construct($message, $code_or_lasterror['type']);
+            parent::__construct(is_null($message) ? "" : $message, $code_or_lasterror['type']);
             $this->file = $code_or_lasterror['file'];
             $this->line = $code_or_lasterror['line'];
         } else {
-            parent::__construct($message, $code_or_lasterror);
+            parent::__construct(is_null($message) ? "" : $message, is_null($code_or_lasterror) ? 0 : $code_or_lasterror);
         }
     }
 

--- a/lib/Horde/Exception/NotFound.php
+++ b/lib/Horde/Exception/NotFound.php
@@ -36,6 +36,6 @@ class Horde_Exception_NotFound extends Horde_Exception
         if (is_null($message)) {
             $message = Horde_Exception_Translation::t("Not Found");
         }
-        parent::__construct($message, $code);
+        parent::__construct($message, is_null($code) ? 0 : $code);
     }
 }

--- a/lib/Horde/Exception/Pear.php
+++ b/lib/Horde/Exception/Pear.php
@@ -36,7 +36,9 @@ class Horde_Exception_Pear extends Horde_Exception
      */
     public function __construct(PEAR_Error $error)
     {
-        parent::__construct($error->getMessage(), $error->getCode());
+        $message = $error->getMessage();
+        $code = $error->getCode();
+        parent::__construct(is_null($message) ? "" : $message, is_null($code) ? 0 : $code);
         $this->details = $this->_getPearTrace($error);
     }
 

--- a/lib/Horde/Exception/PermissionDenied.php
+++ b/lib/Horde/Exception/PermissionDenied.php
@@ -36,6 +36,6 @@ class Horde_Exception_PermissionDenied extends Horde_Exception
         if (is_null($message)) {
             $message = Horde_Exception_Translation::t("Permission Denied");
         }
-        parent::__construct($message, $code);
+        parent::__construct($message, is_null($code) ? 0 : $code);
     }
 }

--- a/lib/Horde/Exception/Wrapped.php
+++ b/lib/Horde/Exception/Wrapped.php
@@ -51,6 +51,6 @@ class Horde_Exception_Wrapped extends Horde_Exception
             $message = (string)$message->getMessage();
         }
 
-        parent::__construct($message, $code, $previous);
+        parent::__construct(is_null($message) ? "" : $message, $code, $previous);
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Exception/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Exception/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Expetion Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Exception/ExceptionTest.php
+++ b/test/Horde/Exception/ExceptionTest.php
@@ -45,13 +45,13 @@ class Horde_Exception_ExceptionTest extends Horde_Test_Case
     public function testMethodTostringYieldsExceptionDescription()
     {
         $e = new Horde_Exception();
-        $this->assertRegexp('/(exception |^)\'?Horde_Exception\'? in/', (string)$e);
+        $this->assertMatchesRegularExpression('/(exception |^)\'?Horde_Exception\'? in/', (string)$e);
     }
 
     public function testMethodTostringContainsDescriptionOfPreviousException()
     {
         $e = new Horde_Exception("", 0, new Exception('previous'));
-        $this->assertRegexp('/Next( exception)? \'?Horde_Exception\'?/', (string)$e);
+        $this->assertMatchesRegularExpression('/Next( exception)? \'?Horde_Exception\'?/', (string)$e);
     }
 
     // NotFound Exception Testing

--- a/test/Horde/Exception/ExceptionTest.php
+++ b/test/Horde/Exception/ExceptionTest.php
@@ -19,7 +19,7 @@
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
-class Horde_Exception_ExceptionTest extends  PHPUnit_Framework_TestCase
+class Horde_Exception_ExceptionTest extends Horde_Test_Case
 {
 
     // Basic Exception Testing
@@ -134,8 +134,8 @@ class Horde_Exception_ExceptionTest extends  PHPUnit_Framework_TestCase
         try {
             Horde_Exception_Pear::catchError(new PEAR_Error('An error occurred.'));
         } catch (Horde_Exception_Pear $e) {
-            $this->assertContains(
-                'Horde_Exception_ExceptionTest->testCatchingAndConvertingPearErrors unkown:unkown',
+            $this->assertStringContainsString(
+                'Horde_Exception_ExceptionTest->testCatchingAndConvertingPearErrors ',
                 $e->details
             );
         }
@@ -149,7 +149,7 @@ class Horde_Exception_ExceptionTest extends  PHPUnit_Framework_TestCase
                 new PEAR_Error('An error occurred.', null, null, null, 'userinfo')
             );
         } catch (Horde_Exception_Pear $e) {
-            $this->assertContains('userinfo', $e->details);
+            $this->assertStringContainsString('userinfo', $e->details);
         }
     }
 
@@ -161,7 +161,7 @@ class Horde_Exception_ExceptionTest extends  PHPUnit_Framework_TestCase
                 new PEAR_Error('An error occurred.', null, null, null, array('userinfo'))
             );
         } catch (Horde_Exception_Pear $e) {
-            $this->assertContains('[0] => userinfo', $e->details);
+            $this->assertStringContainsString('[0] => userinfo', $e->details);
         }
     }
 

--- a/test/Horde/Exception/ExceptionTest.php
+++ b/test/Horde/Exception/ExceptionTest.php
@@ -38,7 +38,7 @@ class Horde_Exception_ExceptionTest extends Horde_Test_Case
 
     public function testMethodGetpreviousYieldsPreviousException()
     {
-        $e = new Horde_Exception(null, null, new Exception('previous'));
+        $e = new Horde_Exception("", 0, new Exception('previous'));
         $this->assertEquals('previous', $e->getPrevious()->getMessage());
     }
 
@@ -50,7 +50,7 @@ class Horde_Exception_ExceptionTest extends Horde_Test_Case
 
     public function testMethodTostringContainsDescriptionOfPreviousException()
     {
-        $e = new Horde_Exception(null, null, new Exception('previous'));
+        $e = new Horde_Exception("", 0, new Exception('previous'));
         $this->assertRegexp('/Next( exception)? \'?Horde_Exception\'?/', (string)$e);
     }
 


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API https://salsa.debian.org/horde-team/php-horde-exception/-/blob/debian-sid/debian/patches/1001_phpunit-8.x%2B9.x.patch
- Debian changes: Fix PHP warnings https://salsa.debian.org/horde-team/php-horde-exception/-/blob/debian-sid/debian/patches/2010_phpwarnings.patch
- Debian changes: Add 1012_php8.2.patch. https://salsa.debian.org/horde-team/php-horde-exception/-/blob/debian-sid/debian/patches/1012_php8.2.patch
